### PR TITLE
fix: use transport agnostic link for default json

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@ window.onload = function() {
   const ui = SwaggerUIBundle({
     // Default to petstore. LoopBack 4 applications will override it by setting 
     // the url parameter, such as https://loopback.io/api-explorer?url=<swagger-spec-url>
-    url: "http://petstore.swagger.io/v2/swagger.json",
+    url: "//petstore.swagger.io/v2/swagger.json",
     dom_id: '#swagger-ui',
     deepLinking: true,
     filter: true,

--- a/index.loopback.html
+++ b/index.loopback.html
@@ -134,7 +134,7 @@ window.onload = function() {
   const ui = SwaggerUIBundle({
     // Default to petstore. LoopBack 4 applications will override it by setting 
     // the url parameter, such as https://loopback.io/api-explorer?url=<swagger-spec-url>
-    url: "http://petstore.swagger.io/v2/swagger.json",
+    url: "//petstore.swagger.io/v2/swagger.json",
     dom_id: '#swagger-ui',
     deepLinking: true,
     filter: true,

--- a/upgrade-swagger-ui.js
+++ b/upgrade-swagger-ui.js
@@ -31,6 +31,7 @@ async function upgradeSwaggerUI() {
     'LICENSE',
     'oauth2-redirect.loopback.html',
     'package.json',
+    'package-lock.json',
     'README.md',
     'upgrade-swagger-ui.js'
   ];


### PR DESCRIPTION
Signed-off-by: virkt25 <taranveer@virk.cc>

---

Changes the default swagger.json link to be transport agnostic so `https://explorer.loopback.io` doesn't show an error message.